### PR TITLE
Update request@2.88.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "async": "^1.3.0",
     "google-auth-library": "^0.9.6",
     "lodash": "^4.17.10",
-    "request": "~2.29.0",
+    "request": "^2.88.0",
     "xml2js": "~0.4.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "xml2js": "~0.4.0"
   },
   "devDependencies": {
-    "async": "~0.2.9",
     "nodeunit": "~0.8.2"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "dependencies": {
     "async": "^1.3.0",
-    "google-auth-library": "^0.9.6",
+    "google-auth-library": "^0.12.0",
     "lodash": "^4.17.10",
     "request": "^2.88.0",
     "xml2js": "~0.4.0"


### PR DESCRIPTION
Update request and google-auth-library (to bump its request version).

This also makes request replace the deprecated node-uuid for the new uuid, and replaces the use of `~` for the use of `^`, for easier updates on projects depending on this.

This PR also removes async form dev dependencies, as suggested by yarn, due to it being repeated (already loaded as a regular dependency). This is replicating the upstream changes.